### PR TITLE
Fix IP address and network validation

### DIFF
--- a/lib/dhcp_server.ex
+++ b/lib/dhcp_server.ex
@@ -111,8 +111,11 @@ defmodule DHCPServer do
   end
 
   defp ip(addr_bin) do
-    case String.split(addr_bin, ".") do
-      [a, b, c, d] ->  {String.to_integer(a), String.to_integer(b), String.to_integer(c), String.to_integer(d)}
+    addr_bin
+    |> String.to_charlist()
+    |> :inet.parse_ipv4_address()
+    |> case do
+      {:ok, ip_addr} -> ip_addr
       _ -> raise ArgumentError, "#{addr_bin} is not a valid ip address!"
     end
   end


### PR DESCRIPTION
This pull request introduces changes in the IP adresses validation.

### IP address validation

The IP addresses themselves are validated thanks to `:inet.parse_ipv4_address/1`. This avoid `"828.182.38.2881"` being considered valid or `"a.b.c.d"` causing an exception when trying to convert `"a"` to an integer.

### Network validation

The network and broadcast addresses are now calculated from the gateway IP and the netmask. The DHCP range IPs are checked to belong to the same network.

### No more validation for the DNS servers

It is now possible to use a DNS server from another network, like `1.1.1.1`.

* * *

I tried succintly the new functions by making them temporary public and playing with them in IEx. I did not tested more than that but will do tomorrow morning or at some point in the week.

*Aside: it could be a good idea to run `mix format` on the project in the future. However, to provide a cleaner diff I switched off the format-on-save feature on my editor and sticked to the current code style.*