### PR TITLE
Fix domain_servers parsing

### DIFF
--- a/lib/dhcp_server.ex
+++ b/lib/dhcp_server.ex
@@ -75,7 +75,7 @@ defmodule DHCPServer do
     netmask = ip(netmask)
     begin = ip(begin)
     fin = ip(fin)
-    domain_servers = Enum.each(domain_servers, &ip/1)
+    domain_servers = Enum.map(domain_servers, &ip/1)
 
     network = get_network(gateway, netmask)
     broadcast_addr = get_broadcast_addr(network, netmask)


### PR DESCRIPTION
In #6 I’ve indroduced a critical bug where the configuration cannot be parsed, due to `domain_servers` being `:ok` instead of a list as expected. This pull request aims to patch it.