### PR TITLE
Fix functions privacy and add a child_spec to DHCPServer

### DIFF
--- a/lib/dhcp_server.ex
+++ b/lib/dhcp_server.ex
@@ -127,15 +127,15 @@ defmodule DHCPServer do
   end
 
   # Gets the broadcast address for a network.
-  def get_broadcast_addr(ip_addr, netmask)
-  def get_broadcast_addr({a, b, c, d}, {m_a, m_b, m_c, m_d}) do
+  defp get_broadcast_addr(ip_addr, netmask)
+  defp get_broadcast_addr({a, b, c, d}, {m_a, m_b, m_c, m_d}) do
     # Add 256 after a binary NOT as values are not limited to a byte.
     # (~~~0x(...000000)FF becomes 0x(...111111)00, so adding 256 put it back in
     # the range)
     {a ||| (~~~m_a + 256), b ||| (~~~m_b + 256), c ||| (~~~m_c + 256), d ||| (~~~m_d + 256)}
   end
 
-  def validate_range!(begin, fin, network, netmask) do
+  defp validate_range!(begin, fin, network, netmask) do
     begin_net = get_network(begin, netmask)
     fin_net = get_network(fin, netmask)
 

--- a/lib/dhcp_server.ex
+++ b/lib/dhcp_server.ex
@@ -55,6 +55,15 @@ defmodule DHCPServer do
     supervise(children, [strategy: :one_for_one])
   end
 
+  @doc false
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, opts},
+      type: :supervisor
+    }
+  end
+
   ## Private
 
   defp parse_config(opts, interface) do

--- a/lib/dhcp_server.ex
+++ b/lib/dhcp_server.ex
@@ -75,7 +75,7 @@ defmodule DHCPServer do
     netmask = ip(netmask)
     begin = ip(begin)
     fin = ip(fin)
-    domain_servers = Enum.each(domain_servers, &ip/1)
+    domain_servers = Enum.map(domain_servers, &ip/1)
 
     network = get_network(gateway, netmask)
     broadcast_addr = get_broadcast_addr(network, netmask)


### PR DESCRIPTION
This pull request is on top of #7 and adds a few enhancements. I’ve made it in a separate pull request as it is not critical.

With the changes introduced, one can now define an application start like this:

```elixir
def start(_type, _args) do
  dhcp_options = [
    gateway: "192.168.254.1",
    netmask: "255.255.255.0",
    range: {"192.168.254.10", "192.168.254.99"},
    domain_servers: ["192.168.254.1"]
  ]

  children = [
    {DHCPServer, ["eth0", dhcp_options]}
  ]

  opts = [strategy: :one_for_one, name: ScannerGatewayFirmware.Supervisor]
  Supervisor.start_link(children, opts)
end
```